### PR TITLE
running: update Git repo URL and rules

### DIFF
--- a/templates/Pages/rules_submission.php
+++ b/templates/Pages/rules_submission.php
@@ -16,105 +16,95 @@
     <h3>Submission Rules</h3>
 
     <p>
-        The following rules should ensure a fair comparison of the IO-500 results between systems and configurations. They serve to reduce mistakes and improve accuracy.
+        The following rules should ensure a fair comparison of the IO500 results between systems and configurations. They serve to reduce mistakes and improve accuracy.
     </p>
 
     <ol>
         <li>
-            The latest version of <span class="code">io500.sh</span> in GitHub must be used and all binaries should be built according to the included build instructions.</li>
-
+            Submissions are made using the latest version of the IO500 application in GitHub and all binaries should be built according to the included build instructions.
             <p class="code-block">
-                $ git clone https://github.com/VI4IO/io-500-dev.git -b io500-sc-19                
+                $ git clone https://github.com/IO500/io500.git -b io500-sc20                
             </p>
-        </li>
-        <li>
-            All required phases must be run and in the same order as they appear in the <span class="code">io500.sh</span> script.
         </li>
         <li>
             Read-after-write semantics: The system must be able to correctly read freshly written data from a different client after the close operation on the writer has been completed.
         </li>
-        <li>
-            All create phases should run for at least 300 seconds; the stonewall flag must be set to 300 which should ensure this.
-        </li>
-        <ul>
+	<ol>
             <li>
-                We defined a very high workload for all benchmarks that should satisfy this requirement but you may have to set higher values.
+                All create/write phases must run for at least 300 seconds; the stonewall flag must be set to 300 which should ensure this.
             </li>
-        </ul>
-        <li>
-            There can be no edits made to the <span class="code">io-500.sh</span> script beyond changing the allowed variables and adding commands to configure the storage system (e.g. setting striping parameters).
-        </li>
-        <ul>
-            <li>
-                For example, there can be no artificial delays added within the script such as calling <span class="code">sleep</span> between phases.
-            </li>
-            <li>
-                No edits are allowed to the <span class="code">utilities/io500_fixed.sh</span> scripts.
-            </li>
-        </ul>
+            <ol>
+                <li>
+                    We defined a very high workload for all benchmarks that should satisfy this requirement but you may have to set higher values.
+                </li>
+                <li>
+                    There can be no edits made to the source code including used codes such as <span class="code">IOR</span> beyond changing the allowed variables and adding commands to configure the storage system in <span class="code">io500.sh</span> (e.g. setting striping parameters).
+		</li>
+		<li>An exception to this rule is possible for submitters who have a legitimate reason by requesting an exception from the committee via <a href="mailto:committee@io500.org" class="link">committe@io500.org</a>.
+                </li>
+            </ol>
+	</ol>
         <li>
             The file names for the mdtest and IOR output files may not be pre-created.
         </li>
         <li>
-            You must run the benchmark on a single storage system.
+            You must run all phases of the benchmark on a single storage system without interruption.
+        </li>
+        <li>
+	    There is no limitation on the number of storage nodes, the storage
+	    servers may optionally be co-located on the client nodes.
         </li>
         <li>
             All data must be written to persistent storage within the measured time for the individual benchmark,e.g. if a file system caches data, it must ensure that data is persistently stored before acknowledging the close.
         </li>
         <li>
-            Submitting the results must be done in accordance with the instructions on our submission page.
+            Submitting the results must be done in accordance with the instructions on our submission page. Please verify the correctness of your submission before you submit it.
         </li>
         <li>
-            If a tool other than the included pfind is used for the find phase, then it must follow the same input and output behavior as the included pfind.
+            If a tool other than the included pfind is used for the find phase, then it must follow the same input and output behavior as the included pfind, and the source code must be included in the submission.
+	    <ol>
+	        It is not required to capture the list of matched files.
+	    </ol>
         </li>
         <li>
-            Please also refer to the <span class="code">README</span> documents in the github repo.
+            Please also refer to the <a href="https://github.com/IO500/io500/blob/main/README.md" class="link">README</a> documents in the GitHub repo.
         </li>
         <li>
-            Please read the <span class="code">CHANGELOG.md</span> file for the new changes on the IO-500 benchmark
+            Please read the <a href="https://github.com/IO500/io500/blob/main/CHANGELOG.md" class="link">CHANGELOG.md</a> file for the new changes on the IO500 benchmark
         </li>
         <li>
-            For the 10 node challenge, there must be exactly 10 physical nodes and at least one benchmark process must run on each
+	    Only submissions using at least 10 physical client nodes are
+	    eligible to win IO500 awards and at least one benchmark process
+	    must run on each client.
+            <ol>
+                <li>
+		    We accept results on fewer nodes for documentation
+		    purposes but they cannot be awarded.
+	        </li>
+	        <li>
+		    Virtual machines can be used but the above rule must be followed. More than one virtual machine can be run on each physical node.</li>
+	        </li>
+	        <li>
+                    For the 10 node challenge, there must be exactly 10 physical client nodes and at least one benchmark process must run on each node.
+	        </li>
+	        <li>
+		    The only exception to this rule is the find benchmark,
+		    which may optionally use fewer nodes/processes.
+		</li>
+	    </ol>
         </li>
-        <ul>
-            <li>Virtual machines can be used but the above rule must be followed. More than one virtual machine can be run on each physical node.</li>
-        </ul>
+        <li>
+	    Each of the four main phases (IOR easy and hard, mdtest easy and
+	    hard) has a directory which can be precreated and tuned (e.g.
+	    using tools such as "<span class="code">lfs setstripe</span>" or
+	    "<span class="code">beegfs_ctl</span>"; however, additional
+	    subdirectories within these directories cannot be precreated.
+        </li>
     </ol>
 
     <p>
         Please send any requests for changes to these rules or clarifying questions to our mailing list.
     </p>
-
-    <h4>Allowed Modifications</h4>
-
-    <p>
-        Inside the <span class="code">io500.sh</span> script you can make the modifications as indicated by the script, in particular these are:
-    </p>
-
-    <ol>
-        <li>
-            In the <span class="code">setup_directories()</span> function, change in which directory to run and set directory options (e.g. using tools such as <span class="code">lfs_setstripe</span> or <span class="code">beegfs_ctl</span> to specify different stripe size for the IOR easy directory and the IOR hard directory) Each of the four main phases (IOR easy and hard, and mdtest easy and hard) has a subdirectory on which these various options can be set; however, additional subdirectories within these subdirectories cannot be created.
-        </li>
-        <li>
-            In <span class="code">setup_paths()</span> set the MPI arguments.
-        </li>
-        <li>
-            In <span class="code">setup_find()</span>, you can choose the application that performs the find.
-        </li>
-        <li>
-            In <span class="code">extra_description()</span>, you can add all the variables about the system information; this is useful when conducting many runs. While we query this information as well in the web submission, the web submission will read any value from the script.
-        </li>
-        <li>
-            Running with a stricter semantics such as <span class="code">O_DIRECT</span> is allowed.
-        </li>
-        <li>
-            In the <span class="code">setup_ior</span>, <span class="code">mdtest_easy</span>, <span class="code">mdtest_hard</span> functions you can set the arguments for running the benchmarks. Details of allowed options are provided inside the script. As a rule of thumb, the hard benchmarks tolerate only options that do not change the access pattern. The easy patterns allow more changes as the intention is to show best-case performance (without explicit caching).
-        </li>
-
-        <p>
-            Please email the mailing list or the steering board for any clarifications.
-        </p>
-    </ol>
 
     <div id="disqus_thread"></div>
 </div>

--- a/templates/Pages/running.php
+++ b/templates/Pages/running.php
@@ -10,7 +10,7 @@
     <ul>
         <li>
             <?php
-            echo $this->Html->link(__('Get IO500'), 'https://github.com/VI4IO/io-500-dev', [
+            echo $this->Html->link(__('Get IO500'), 'https://github.com/IO500/io500', [
                 'class' => 'button-highlight'
             ]);
             ?>
@@ -30,9 +30,9 @@
     <p>The IO500 source code is available at Github:</p>
 
     <p class="code-block">
-        $ git clone https://github.com/VI4IO/io-500-dev.git -b io500-sc-19<br/>
-        $ cd io-500-dev<br/>
-        $ ./utilities/prepare.sh<br/>
+        $ git clone https://github.com/IO500/io500.git -b io500-sc20<br/>
+        $ cd io500<br/>
+        $ ./prepare.sh<br/>
     </p>
 
     <h3>Installation</h3>
@@ -49,10 +49,10 @@
 
     <ol>
         <li>
-            Create a job submission script (if applicable) to execute the <span class="code">io500.sh</span> script which is located in the <span class="code">io-500-dev</span> folder. Provide enough execution time and adjust the reserved resources.
+            Create a job submission script (if applicable) to execute the <span class="code">io500.sh</span> script which is located in the <span class="code">io500</span> folder. Provide enough execution time (typically 2h would be enough for the full run) and adjust the reserved resources.
         </li>
         <li>
-            Edit the <span class="code">io500.sh</span> file to tune the parameters and activate or disable some test cases. Remember that you need to execute all the mandatory tests for a valid submission.
+            Edit the <span class="code">io500.sh</span> file to set allowed parameters, and create a .ini file using "<span class="code">./io500 --list &gt; myconfig.ini</span>" and edit available parameters. Remember that you need to execute all the mandatory tests for a valid submission.
             <ul>
                 <li>
                     Adjust the variables io500_mpirun and to <span class="code">io500_mpiargs</span> according to your system and test case.
@@ -66,7 +66,8 @@
             </ul>
         </li>
         <li>
-            Execute your submission job script.
+            Execute your submission job script that runs the
+	    "<span class="code"> io500.sh myconfig.ini</span>" script.
         </li>
         <li>
             Verify that all the results are valid.
@@ -77,10 +78,18 @@
     </ol>
 
     <p>
-        A video with the execution and tuning procedure is here.
+        A video with the execution and tuning procedure is
+	<a href="https://www.youtube.com/watch?v=FRTK9KwPCmg" class="link">here</a>.
     </p>
     <p>
-        When you modify tunables check that the changes are allowed according to the IO-500 rules.
+        When you modify tunables check that the changes are allowed according to the
+                <?php
+                echo $this->Html->link(__('IO500 Submission Rules'), [
+                    'controller' => 'pages',
+                    'action' => 'display',
+                    'rules-submission'
+                ]);
+                ?>.
     </p>
 
     <div id="disqus_thread"></div>

--- a/templates/Pages/submission.php
+++ b/templates/Pages/submission.php
@@ -39,8 +39,8 @@
             If you experience any problems with the online form; send an <a href="mailto:submit@io500.org" class="link">email</a> with attachments:
 
             <ul>
-                <li>The (potentially) adapted io500.sh</li>
-                <li>The output directory of the benchmark (variable io500_result_dir in io500.sh)</li>
+                <li>The (potentially) adapted <span class="code">io500.sh</span></li>
+                <li>The output directory of the benchmark (variable <span class="code">io500_result_dir</span> in <span class="code">io500.sh</span>)</li>
                 <li>If possible, please mention which system is covered of the <a href="https://www.vi4io.org/hpsl/start" class="link">CDCL</a> or provide system information such that we can add the system to the CDCL!</li>
             </ul>
         </li>


### PR DESCRIPTION
Update the Git repo URL to reflect the new IO500/io500 URL,
as well as all the rules that reference it.

Update related rules to match the VI4IO pages from the last update.

Signed-off-by: Andreas Dilger <adilger@dilger.ca>