### PR TITLE
Configure automatic deployment upon commits on main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: CD
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  push:
+    branches: [ main ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "deploy"
+  deploy:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Deploy to server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SERVER_IP }}
+          username: ${{ secrets.SERVER_USERNAME }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          script: cd ${{ secrets.PROJECT_PATH }} && git pull


### PR DESCRIPTION
This configures GitHub Actions to automatically deploy the changes approved by the committee to the server. Once approved, it basically instantiate a runner to ssh to the server and pull the changes to production.

Detailed documentation about how this file is configured can be found at: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/introduction-to-github-actions  

Before accepting this merge, please, make sure the GitHub Secrets have been configured with the necessary variables: `SERVER_IP`, `SERVER_USERNAME`, `SERVER_PASSWORD`, `PROJECT_PATH`. You can access that in the repository's Settings under Secrets. Secrets are environment variables that are encrypted and only exposed to selected actions. They are not passed to workflows that are triggered by a pull request from a fork, so it is safe to use.