### PR TITLE
missing link to main rules from SCC

### DIFF
--- a/templates/Pages/rules_scc_submission.php
+++ b/templates/Pages/rules_scc_submission.php
@@ -16,7 +16,15 @@
     <h3>Submission Student Cluster Competition Rules</h3>
 
     <p>
-        Please refer to the IO500 rules webpage; all rules are in effect with three exceptions.
+        Please refer to the 
+    <?php
+                echo $this->Html->link(__('IO500 Submission Rules'), [
+                    'controller' => 'pages',
+                    'action' => 'display',
+                    'rules-submission'
+                ]);
+   ?>
+all rules are in effect with three exceptions.
     </p>
 
     <ol>


### PR DESCRIPTION
There is missing link from SCC rules to main rules page. Need to verify that the modification is good.