### PR TITLE
Fix to display new lists only after their release dates

### DIFF
--- a/src/Controller/ReleasesController.php
+++ b/src/Controller/ReleasesController.php
@@ -19,6 +19,9 @@ class ReleasesController extends AppController
     public function index()
     {
         $releases = $this->Releases->find('all')
+            ->where([
+                'Releases.release_date <=' => date('Y-m-d')
+            ])
             ->order([
                 'Releases.release_date' => 'ASC',
             ]);

--- a/src/Controller/SubmissionsController.php
+++ b/src/Controller/SubmissionsController.php
@@ -116,6 +116,7 @@ class SubmissionsController extends AppController
 
         $release = $this->Submissions->Releases->find('all')
             ->where([
+                'Releases.release_date <=' => date('Y-m-d'),
                 'Releases.acronym' => strtoupper($list)
             ])
             ->first();
@@ -193,6 +194,7 @@ class SubmissionsController extends AppController
 
         $release = $this->Submissions->Releases->find('all')
             ->where([
+                'Releases.release_date <=' => date('Y-m-d'),
                 'Releases.acronym' => strtoupper($list)
             ])
             ->first();
@@ -275,6 +277,7 @@ class SubmissionsController extends AppController
 
         $release = $this->Submissions->Releases->find('all')
             ->where([
+                'Releases.release_date <=' => date('Y-m-d'),
                 'Releases.acronym' => strtoupper($list)
             ])
             ->first();
@@ -352,6 +355,7 @@ class SubmissionsController extends AppController
 
         $release = $this->Submissions->Releases->find('all')
             ->where([
+                'Releases.release_date <=' => date('Y-m-d'),
                 'Releases.acronym' => strtoupper($list)
             ])
             ->first();


### PR DESCRIPTION
Fix to display new lists, e.g. SC20, only after their release dates.