### PR TITLE
fix: update path to IO500 storage files

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -397,5 +397,5 @@ return [
      */
     'Session' => [
         'defaults' => 'php',
-    ],
+    ]
 ];

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -90,4 +90,8 @@ return [
             'url' => env('EMAIL_TRANSPORT_DEFAULT_URL', null),
         ],
     ],
+
+    'IO500' => [
+        'storage' => null
+    ]
 ];

--- a/src/Controller/SubmissionsController.php
+++ b/src/Controller/SubmissionsController.php
@@ -450,7 +450,7 @@ class SubmissionsController extends AppController
      */
     public function view($id = null)
     {
-        $prefix = '/home/jbez/jbez.io500.org/storage/';
+        $prefix = Configure::read('IO500.storage');
 
         $submission = $this->Submissions->get($id, [
             'contain' => [],

--- a/templates/Submissions/view.php
+++ b/templates/Submissions/view.php
@@ -254,7 +254,7 @@
                     <?php
                     echo $this->Html->link(
                         _('Browse Files'),
-                        'https://jbez.io500.org/storage/' . $submission->information_list_name . '/' . str_replace('.zip', '', $submission->storage_data),
+                        'https://io500.org/storage/' . $submission->information_list_name . '/' . str_replace('.zip', '', $submission->storage_data),
                         [
                             'target' => '_blank',
                             'class' => 'button'
@@ -266,7 +266,7 @@
                     <?php
                     echo $this->Html->link(
                         _('Download ZIP'),
-                        'https://jbez.io500.org/storage/' . $submission->information_list_name . '/' . $submission->storage_data,
+                        'https://io500.org/storage/' . $submission->information_list_name . '/' . $submission->storage_data,
                         [
                             'target' => '_blank',
                             'class' => 'button-highlight'


### PR DESCRIPTION
This commit removes a hard-coded path for the submission files and include the correct path (not in jbez.io500.org anymore) in the secret configuration file `app_local.php` at the server. I have updated the `app_local.example.php` accordingly.