### PR TITLE
update: view submission with new file names

### DIFF
--- a/src/Controller/SubmissionsController.php
+++ b/src/Controller/SubmissionsController.php
@@ -469,17 +469,6 @@ class SubmissionsController extends AppController
             'mdtest_hard_write',
             'mdtest_hard_read',
             'result_summary',
-            'ior-easy-read',
-            'ior-easy-write',
-            'ior-hard-read',
-            'ior-hard-write',
-            'mdtest-easy-delete',
-            'mdtest-easy-stat',
-            'mdtest-easy-write',
-            'mdtest-hard-delete',
-            'mdtest-hard-stat',
-            'mdtest-hard-write',
-            'mdtest-hard-read',
             'result.txt',
             'result-summary.txt',
             'io500.sh',
@@ -498,7 +487,10 @@ class SubmissionsController extends AppController
                 if ($file->isFile()) {
                     foreach ($target_files as $target) {
                         if (
-                            strpos($file->getPathname(), $target) !== false &&
+                            (
+                             strpos($file->getPathname(), $target) !== false || 
+                             strpos(str_replace('_', '-', $file->getPathname()), str_replace('_', '-', $target)) !== false
+                            ) &&
                             strpos($file->getPathname(), '._') === false
                         ) {
                             $selected_files[] = $file->getPathname();

--- a/src/Controller/SubmissionsController.php
+++ b/src/Controller/SubmissionsController.php
@@ -480,7 +480,9 @@ class SubmissionsController extends AppController
             'mdtest-hard-stat',
             'mdtest-hard-write',
             'mdtest-hard-read',
-            'result-summary',
+            'result.txt',
+            'result-summary.txt',
+            'io500.sh',
         ];
 
         $selected_files = [];

--- a/src/Controller/SubmissionsController.php
+++ b/src/Controller/SubmissionsController.php
@@ -469,6 +469,18 @@ class SubmissionsController extends AppController
             'mdtest_hard_write',
             'mdtest_hard_read',
             'result_summary',
+            'ior-easy-read',
+            'ior-easy-write',
+            'ior-hard-read',
+            'ior-hard-write',
+            'mdtest-easy-delete',
+            'mdtest-easy-stat',
+            'mdtest-easy-write',
+            'mdtest-hard-delete',
+            'mdtest-hard-stat',
+            'mdtest-hard-write',
+            'mdtest-hard-read',
+            'result-summary',
         ];
 
         $selected_files = [];


### PR DESCRIPTION
This updates the view page of a submission to also display the output files considering the new naming format. For instance, `ior_easy_read` was renamed to `ior-eay-read` in the latest version of the benchmark. This update will filter the files considering both names.