### PR TITLE
fix #53: remove non existing lists

### DIFF
--- a/templates/Releases/index.php
+++ b/templates/Releases/index.php
@@ -5,7 +5,8 @@
             <li>
                 <h4><?php echo strtoupper($release->acronym); ?></h4>
 
-                <ul>                    
+                <ul>
+                    <?php if ($release->enable_ranked_list) { ?>
                     <li>
                         <?php
                         echo $this->Html->link(__('IO500'), [
@@ -15,6 +16,8 @@
                         ]);
                         ?>
                     </li>
+                    <?php } ?>
+                    <?php if ($release->enable_10_node_list) { ?>
                     <li>
                         <?php
                         echo $this->Html->link(__('10 NODE'), [
@@ -24,6 +27,8 @@
                         ]);
                         ?>
                     </li>
+                    <?php } ?>
+                    <?php if ($release->enable_full_list) { ?>
                     <li>
                         <?php
                         echo $this->Html->link(__('FULL'), [
@@ -32,7 +37,9 @@
                             strtolower($release->acronym)
                         ]);
                         ?>
-                    </li>                    
+                    </li>
+                    <?php } ?>
+                    <?php if ($release->enable_historical_list) { ?>
                     <li>
                         <?php
                         echo $this->Html->link(__('HISTORICAL'), [
@@ -42,6 +49,7 @@
                         ]);
                         ?>
                     </li>
+                    <?php } ?>
                 </ul>
             </li>
             <?php } ?>


### PR DESCRIPTION
We can now control which lists are displayed for each release from the database to display existing official lists. I've already updated the database so that once this PR is approved, we will only show the following:

![Screenshot from 2020-11-12 17-21-24](https://user-images.githubusercontent.com/5297080/98992388-e615fa00-250b-11eb-870f-0d33640054c7.png)
