### PR TITLE
fix: missing filter on customize list

### DIFF
--- a/src/Controller/SubmissionsController.php
+++ b/src/Controller/SubmissionsController.php
@@ -634,7 +634,11 @@ class SubmissionsController extends AppController
         $display = [];
 
         $submissions = $this->Submissions->find('all')
+            ->contain([
+                'Releases'
+            ])
             ->where([
+                'Releases.release_date <=' => date('Y-m-d'),
                 'Submissions.information_list_name IS NOT' => null,
             ])
             ->order([


### PR DESCRIPTION
Fix missing filter on the new custom list page to avoid showing new results.