### PR TITLE
update: stop grouping results in full and historical lists

### DIFF
--- a/src/Controller/SubmissionsController.php
+++ b/src/Controller/SubmissionsController.php
@@ -273,8 +273,6 @@ class SubmissionsController extends AppController
     {
         $limit = Configure::read('IO500.pagination');
 
-        $limit = 1000;
-
         $release = $this->Submissions->Releases->find('all')
             ->where([
                 'Releases.release_date <=' => date('Y-m-d'),
@@ -283,38 +281,17 @@ class SubmissionsController extends AppController
             ->first();
 
         $submissions = $this->Submissions->find('all')
-            ->select([
-                'Submissions.id',
-                'Submissions.information_system',
-                'Submissions.information_institution',
-                'Submissions.information_system',
-                'Submissions.information_filesystem_type',
-            ])
             ->where([
                 'Submissions.information_submission_date <=' => $release->release_date->format('Y-m-d'),
-                'Submissions.valid_from <=' => $release->release_date
-            ])
-            ->order([
-                'Submissions.io500_score' => 'DESC',
-            ])
-            ->limit($limit);
-
-        $storages = [];
-        $valid_records = [];
-        
-        // We need to remove duplicate entries from submissions of the same system
-        foreach ($submissions as $submission) {
-            $key = $submission->information_institution . ' ' .
-                $submission->information_system . ' ' .
-                $submission->information_filesystem_type;
-
-            if (!in_array($key, $storages)) {
-                $storages[] = $key;
-                $valid_records[] = $submission->id;
-            }
-        }
-
-        $limit = Configure::read('IO500.pagination');
+                'Submissions.valid_from <=' => $release->release_date,
+                'OR' => [
+                    'Submissions.valid_to IS NULL',
+                    'Submissions.valid_to >=' => $release->release_date,
+                ],
+                'Submissions.status IN' => [
+                    'VALID', 'INVALID'
+                ]
+            ]);
 
         $settings = [
             'order' => [
@@ -327,14 +304,6 @@ class SubmissionsController extends AppController
             $settings['sortWhitelist'][] = $this->request->getParam('?')['sort'];
         }
 
-        $submissions = $this->Submissions->find('all')        
-            ->contain([
-                'Releases'
-            ])
-            ->where([
-                'Submissions.id IN' => $valid_records,
-            ])
-            ->limit($limit);
 
         $this->set('limit', $limit);
         $this->set('release', $release);


### PR DESCRIPTION
This update will allow the full and historical lists to display all the valid records accordingly, without grouping them as it was doing.