### PR TITLE
Fix hypenated io 500

### DIFF
--- a/templates/Pages/about.php
+++ b/templates/Pages/about.php
@@ -113,7 +113,7 @@
     <?php
     echo $this->Html->link(
         __('Download the Logo'),
-        'https://www.vi4io.org/_media/io500/about/logo-io500.pdf',
+        '../img/logo.png',
         [
             'class' => 'button'
         ]

--- a/templates/Pages/steering.php
+++ b/templates/Pages/steering.php
@@ -16,13 +16,17 @@
     <h3>Community</h3>
 
     <p>
-        The community provides suggestions and is asked to provide feedback on relevant questions before decisions are made. It is organized officially via Birds-of-a-feather sessions during the ISC-HPC and Supercomputing conference series. Everyone is welcome to attend the <a href="https://www.vi4io.org/listinfo/io-500" class="link">mailing list</a> and our <a href="https://join.slack.com/t/vi4io/shared_invite/zt-2z12x7o1-xhWH3WAQJRktDwy0hSus~g" class="link">Slack channel</a> to discuss issues and participate.
+        The community provides suggestions and is asked to provide feedback on relevant questions before decisions are made. 
+        It is organized officially via Birds-of-a-feather sessions during the ISC-HPC and Supercomputing conference series. 
+        Everyone is welcome to join the <a href="http://lists.io500.org/listinfo.cgi/io500-io500.org" class="link">mailing list</a> and 
+        our <a href="https://join.slack.com/t/io500workspace/shared_invite/zt-hv1i5svr-Yj8HR_wRzEy1bK2s2JX20w" class="link">Slack channel</a> to discuss issues and participate.
     </p>
 
     <h3>Advisory committee</h3>
 
     <p>
-        This committee provides a closed but fair playing field for all vendors to discuss issues together with the steering committee. Its purpose is to encourage the vendors to participate but allowing vendors to benefit from further information. If you are interested to join apply to the <a href="https://www.vi4io.org/listinfo/io-500" class="link">mailing list</a>.
+        This committee provides a closed but fair playing field for all vendors to discuss issues together with the steering committee. Its purpose is to encourage the vendors to participate but allowing vendors to benefit from further information. 
+        If you are interested to join, please join the <a href="http://lists.io500.org/listinfo.cgi/io500-io500.org" class="link">mailing list</a>.
     </p>
 
     <h3>Further Reading</h3>

--- a/templates/element/footer.php
+++ b/templates/element/footer.php
@@ -11,7 +11,7 @@
                     <?php
                     echo $this->Html->link(
                         file_get_contents('img/mail.svg'),
-                        'https://www.vi4io.org/listinfo/IO-500',
+                        'http://lists.io500.org/listinfo.cgi/io500-io500.org',
                         [
                             'escape' => false,
                             'target' => '_blank'


### PR DESCRIPTION
Updated places that had old URLs as well as old usage of 'IO-500' instead of 'IO500'