### PR TITLE
remove use of "find easy" in pages

### DIFF
--- a/templates/Submissions/pfind.php
+++ b/templates/Submissions/pfind.php
@@ -1,7 +1,7 @@
 <div class="submissions index content">
     <ul class="plots">
         <li>
-            <h3>PFind Easy</h3>
+            <h3>Find</h3>
             <iframe src="<?php echo $this->Url->build('/'); ?>/plots/plotly/io500-find-easy.html"></iframe>
         </li>
     </ul>

--- a/templates/Submissions/view.php
+++ b/templates/Submissions/view.php
@@ -205,7 +205,7 @@
                             <td><?php echo $this->Number->format($submission->ior_hard_read, ['places' => 2, 'precision' => 2]) ?> GiB/s</td>
                         </tr>
                         <tr>
-                            <th><?php echo _('Find Easy') ?></th>
+                            <th><?php echo _('Find') ?></th>
                             <td><?php echo $this->Number->format($submission->pfind_easy, ['places' => 2, 'precision' => 2]) ?> kIOP/s</td>
                         </tr>
                     </table>


### PR DESCRIPTION
There is no "find easy" phase, so this should not be displayed in any pages.

Closes #71