### PR TITLE
lists: limit IO500 ranked list to 10+ clients

### DIFF
--- a/src/Controller/SubmissionsController.php
+++ b/src/Controller/SubmissionsController.php
@@ -18,11 +18,23 @@ use NXP\Exception\UnknownVariableException;
  *
  * @property \App\Model\Table\SubmissionsTable $Submissions
  * @method \App\Model\Entity\Submission[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
+ *
+ * This generates the different types of lists.  As described in 'about.php'
+ * there are 4 main categories of lists:
+ *
+ * Historic list: all submissions ever received (function historical())
+ * Full list: subset of Historic list that are currently valid (function full())
+ * IO500 list: subset of Full list marked for inclusion in IO500 ranked list,
+ *    showing one highest-scoring result per storage system (function latest())
+ * 10-Node Challenge list: subset of Full list run on exactly 10 client nodes
+ *    and marked for inclusion in the 10-Node Challenge ranked list, showing
+ *    only one highest-scoring result per storage system (function ten())
+ * Custom list: user-generated list with custom ranking (function customize())
  */
 class SubmissionsController extends AppController
 {
     /**
-     * Lastest method
+     * Latest method
      *
      * @return \Cake\Http\Response|null|void Renders view
      */
@@ -54,6 +66,7 @@ class SubmissionsController extends AppController
                     'Submissions.valid_to IS NULL',
                     'Submissions.valid_to >=' => $release->release_date,
                 ],
+                'Submissions.information_client_nodes >=' => 10,
                 'Submissions.include_in_io500 IS' => true,
                 'Submissions.status' => 'VALID',
             ])
@@ -214,6 +227,7 @@ class SubmissionsController extends AppController
                     'Submissions.valid_to IS NULL',
                     'Submissions.valid_to >=' => $release->release_date,
                 ],
+                'Submissions.information_client_nodes >=' => 10,
                 'Submissions.include_in_io500 IS' => true,
                 'Submissions.status' => 'VALID',
             ])

--- a/templates/Pages/about.php
+++ b/templates/Pages/about.php
@@ -37,9 +37,15 @@
 
     <ul>
         <li><strong>Historic list</strong>: all submissions ever received</li>
-        <li><strong>Full list</strong>: the subset from the historic list that was valid</li>
-        <li><strong>IO500 List</strong>: the subset from the full list with only the best submission per storage system</li>
-        <li><strong>10 Node Challenge List</strong>: the subset from the full list with only the best submission per storage system ran on exactly ten nodes</li>
+        <li><strong>Full list</strong>: the subset of the Historic list of
+            submissions that are currently valid</li>
+        <li><strong>IO500 List</strong>: the subset of the Full list of
+            submissions marked for inclusion in the IO500 ranked list, showing
+            only one highest-scoring result per storage system</li>
+        <li><strong>10-Node Challenge List</strong>: the subset from the Full
+            list of submissions run on exactly ten nodes and marked for
+            inclusion in the 10-Node Challenge ranked list, showing only one
+            highest-scoring result per storage system</li>
     </ul>
 
     <h3>Workloads</h3>


### PR DESCRIPTION
According to the submssion rules, only submissions with at least
10 client nodes should be included in the ranked list.

I'm not totally clear on the difference between "list" and "latest" so I added the restriction to both functions.