### PR TITLE
fix 63: include easy navigation between lists

### DIFF
--- a/src/Controller/SubmissionsController.php
+++ b/src/Controller/SubmissionsController.php
@@ -179,6 +179,7 @@ class SubmissionsController extends AppController
             ->limit($limit);
 
         $this->set('limit', $limit);
+        $this->set('release', $release);
         $this->set('submissions', $this->paginate($submissions, $settings));
     }
 
@@ -260,6 +261,7 @@ class SubmissionsController extends AppController
             ->limit($limit);
 
         $this->set('limit', $limit);
+        $this->set('release', $release);
         $this->set('submissions', $this->paginate($submissions, $settings));
     }
 

--- a/templates/Submissions/full.php
+++ b/templates/Submissions/full.php
@@ -3,8 +3,8 @@
 
     <?php
     $this->Breadcrumbs->add(_('LISTS'), ['controller' => 'releases', 'action' => 'index']);
-    $this->Breadcrumbs->add(_('FULL LIST'), ['controller' => 'releases', 'action' => 'index']);
     $this->Breadcrumbs->add(strtoupper($this->request->getParam('pass')[0]), ['controller' => 'submissions', 'action' => 'full', $this->request->getParam('pass')[0]]);
+    $this->Breadcrumbs->add(_('FULL LIST'), ['controller' => 'releases', 'action' => 'index']);
 
     echo $this->Breadcrumbs->render([], ['separator' => ' / ']);
     ?>
@@ -15,6 +15,46 @@
 
     <div class="submissions-action">
         <?php
+        if ($release->enable_10_node_list) {
+            echo $this->Html->link(_('10-node'), [
+                'controller' => 'submissions',
+                'action' => 'ten',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation'
+            ]);
+        }
+
+        if ($release->enable_ranked_list) {
+            echo $this->Html->link(_('IO500'), [
+                'controller' => 'submissions',
+                'action' => 'list',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation'
+            ]);
+        }
+
+        if ($release->enable_full_list) {
+            echo $this->Html->link(_('Full'), [
+                'controller' => 'submissions',
+                'action' => 'full',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation-active'
+            ]);
+        }
+
+        if ($release->enable_historical_list) {
+            echo $this->Html->link(_('Historical'), [
+                'controller' => 'submissions',
+                'action' => 'historical',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation'
+            ]);
+        }
+
         echo $this->Html->link(_('Customize'), [
             'controller' => 'submissions',
             'action' => 'customize'

--- a/templates/Submissions/historical.php
+++ b/templates/Submissions/historical.php
@@ -3,8 +3,8 @@
 
     <?php
     $this->Breadcrumbs->add(_('LISTS'), ['controller' => 'releases', 'action' => 'index']);
-    $this->Breadcrumbs->add(_('HISTORICAL LIST'), ['controller' => 'releases', 'action' => 'index']);
     $this->Breadcrumbs->add(strtoupper($this->request->getParam('pass')[0]), ['controller' => 'submissions', 'action' => 'historical', $this->request->getParam('pass')[0]]);
+    $this->Breadcrumbs->add(_('HISTORICAL LIST'), ['controller' => 'releases', 'action' => 'index']);
 
     echo $this->Breadcrumbs->render([], ['separator' => ' / ']);
     ?>
@@ -15,7 +15,47 @@
 
     <div class="submissions-action">
         <?php
-        echo $this->Html->link(__('Customize'), [
+        if ($release->enable_10_node_list) {
+            echo $this->Html->link(_('10-node'), [
+                'controller' => 'submissions',
+                'action' => 'ten',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation'
+            ]);
+        }
+
+        if ($release->enable_ranked_list) {
+            echo $this->Html->link(_('IO500'), [
+                'controller' => 'submissions',
+                'action' => 'list',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation'
+            ]);
+        }
+
+        if ($release->enable_full_list) {
+            echo $this->Html->link(_('Full'), [
+                'controller' => 'submissions',
+                'action' => 'full',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation'
+            ]);
+        }
+
+        if ($release->enable_historical_list) {
+            echo $this->Html->link(_('Historical'), [
+                'controller' => 'submissions',
+                'action' => 'historical',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation-active'
+            ]);
+        }
+
+        echo $this->Html->link(_('Customize'), [
             'controller' => 'submissions',
             'action' => 'customize'
         ], [

--- a/templates/Submissions/list.php
+++ b/templates/Submissions/list.php
@@ -3,8 +3,8 @@
 
     <?php
     $this->Breadcrumbs->add(_('LISTS'), ['controller' => 'releases', 'action' => 'index']);
-    $this->Breadcrumbs->add(_('IO500 LIST'), ['controller' => 'releases', 'action' => 'index']);
     $this->Breadcrumbs->add(strtoupper($this->request->getParam('pass')[0]), ['controller' => 'submissions', 'action' => 'list', $this->request->getParam('pass')[0]]);
+    $this->Breadcrumbs->add(_('IO500 LIST'), ['controller' => 'releases', 'action' => 'index']);
 
     echo $this->Breadcrumbs->render([], ['separator' => ' / ']);
     ?>
@@ -15,6 +15,46 @@
 
     <div class="submissions-action">
         <?php
+        if ($release->enable_10_node_list) {
+            echo $this->Html->link(_('10-node'), [
+                'controller' => 'submissions',
+                'action' => 'ten',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation'
+            ]);
+        }
+
+        if ($release->enable_ranked_list) {
+            echo $this->Html->link(_('IO500'), [
+                'controller' => 'submissions',
+                'action' => 'list',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation-active'
+            ]);
+        }
+
+        if ($release->enable_full_list) {
+            echo $this->Html->link(_('Full'), [
+                'controller' => 'submissions',
+                'action' => 'full',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation'
+            ]);
+        }
+
+        if ($release->enable_historical_list) {
+            echo $this->Html->link(_('Historical'), [
+                'controller' => 'submissions',
+                'action' => 'historical',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation'
+            ]);
+        }
+
         echo $this->Html->link(_('Customize'), [
             'controller' => 'submissions',
             'action' => 'customize'

--- a/templates/Submissions/ten.php
+++ b/templates/Submissions/ten.php
@@ -3,8 +3,8 @@
 
     <?php
     $this->Breadcrumbs->add(_('LISTS'), ['controller' => 'releases', 'action' => 'index']);
-    $this->Breadcrumbs->add(_('10 NODE LIST'), ['controller' => 'releases', 'action' => 'index']);
     $this->Breadcrumbs->add(strtoupper($this->request->getParam('pass')[0]), ['controller' => 'submissions', 'action' => 'ten', $this->request->getParam('pass')[0]]);
+    $this->Breadcrumbs->add(_('10 NODE LIST'), ['controller' => 'releases', 'action' => 'index']);
 
     echo $this->Breadcrumbs->render([], ['separator' => ' / ']);
     ?>
@@ -15,6 +15,46 @@
 
     <div class="submissions-action">
         <?php
+        if ($release->enable_10_node_list) {
+            echo $this->Html->link(_('10-node'), [
+                'controller' => 'submissions',
+                'action' => 'ten',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation-active'
+            ]);
+        }
+
+        if ($release->enable_ranked_list) {
+            echo $this->Html->link(_('IO500'), [
+                'controller' => 'submissions',
+                'action' => 'list',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation'
+            ]);
+        }
+
+        if ($release->enable_full_list) {
+            echo $this->Html->link(_('Full'), [
+                'controller' => 'submissions',
+                'action' => 'full',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation'
+            ]);
+        }
+
+        if ($release->enable_historical_list) {
+            echo $this->Html->link(_('Historical'), [
+                'controller' => 'submissions',
+                'action' => 'historical',
+                strtolower($release->acronym)
+            ], [
+                'class' => 'button-navigation'
+            ]);
+        }
+
         echo $this->Html->link(_('Customize'), [
             'controller' => 'submissions',
             'action' => 'customize'

--- a/webroot/css/default.css
+++ b/webroot/css/default.css
@@ -69,6 +69,14 @@ footer {
         margin: 0;
         text-align: left;   
     }
+
+    div.submissions-action {
+        width: 50%;
+    }
+
+    a.button, a.button-navigation, a.button-navigation-active {
+        max-width: 100px;
+    }
 }
 
 @media (min-width: 550px) {
@@ -164,13 +172,31 @@ footer {
     background-size: contain;
 }
 
-.button {
-    border: #d63b1e solid 1px;
+.button, .button-navigation, .button-navigation-active {
     border-radius: 3px;
-    color: #d63b1e;
+    box-sizing: border-box;
+    display: inline-block;
     font-weight: bold;
     padding: 5px 10px;
-    box-sizing: border-box;
+    text-align: center;
+    width: 100px;
+    flex-grow: 1;
+    gap: 10px;
+}
+
+.button {
+    border: #d63b1e solid 1px;
+    color: #d63b1e;
+}
+
+.button-navigation {
+    border: #bbbbbb solid 1px;
+    color: #7b7d82;
+}
+
+.button-navigation-active {
+    border: #222222 solid 1px;
+    color: #222222;
 }
 
 nav {
@@ -588,7 +614,7 @@ dd {
 
 .submissions > h2 {
     float: left;
-    width: 80%;
+    width: 50%;
 }
 
 .submissions > h2 span {
@@ -601,6 +627,13 @@ dd {
 .submissions-action {
     float: right;
     margin: 22px 0;
+    display: flex;
+    width: 100%;
+    flex-wrap: wrap;
+    flex-grow: 1;
+    gap: 10px;
+    box-sizing: border-box;
+    justify-content: flex-end;
 }
 
 /* Breadcumb */


### PR DESCRIPTION
Include an easy way to navigate between lists as we had on the previous website. It will only display the buttons for the existing lists according to the main release screen. This fixes the main issue of #63.

![Screenshot from 2020-12-20 15-07-35](https://user-images.githubusercontent.com/5297080/102720782-21f36a80-42d5-11eb-85cd-68cea4700c12.png)
