### PR TITLE
view: fix data storage node label

### DIFF
--- a/templates/Submissions/view.php
+++ b/templates/Submissions/view.php
@@ -174,11 +174,11 @@
                             <td><?php echo $this->Number->format($submission->information_md_storage_devices) ?></td>
                         </tr>
                         <tr>
-                            <th><?php echo _('Metadata Nodes') ?></th>
+                            <th><?php echo _('Data Nodes') ?></th>
                             <td><?php echo $this->Number->format($submission->information_ds_nodes) ?></td>
                         </tr>
                         <tr>
-                            <th><?php echo _('Metadata Storage Devices') ?></th>
+                            <th><?php echo _('Data Storage Devices') ?></th>
                             <td><?php echo $this->Number->format($submission->information_ds_storage_devices) ?></td>
                         </tr>
                     </table>


### PR DESCRIPTION
Trivial patch to fix incorrectly labelled data storage nodes and devices as metadata nodes/devices.