### PR TITLE
repo: change to team-based reviewer roles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,20 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
-# For more info about this file, please see https://docs.github.com/en/enterprise/2.18/user/github/creating-cloning-and-archiving-repositories/about-code-owners
+# For more info about this file, please see
+# https://docs.github.com/en/enterprise/2.18/user/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-# These owners will be the default owners for everything in
+# These owners will be the default reviewers for everything in
 # all repos in the io500 org.
-*       @adilger @gflofst @gmarkomanolis @seattleplus @JulianKunkel
+*       @io500/web_reviewers
+
+# this is the top-level contact page
+templates/Pages/about.php @io500/board
+
+# these are the rules pages
+templates/Pages/rules*.php @io500/board
+
+# this displays the ranked, full, and historical lists
+src/Controller/SubmissionsController.php @io500/board
+
+# this directory controls the permissions/review requirements
+.github/       @io500/board


### PR DESCRIPTION
Change CODEOWNERS to select patch reviewers based on a team
instead of individual users.  Unfortunately, while this can
automatically select reviewers for a particular page, it does
not affect how many reviewers are required for a page to be
merged.  That can only be configured on a per-branch or per-
repository basis, and needs to be set at the minimum number
of reviewers for any page landing to be approved.