### PR TITLE
view: show "find_easy" instead of "pfind_easy"

### DIFF
--- a/templates/Submissions/view.php
+++ b/templates/Submissions/view.php
@@ -206,7 +206,7 @@
                         </tr>
                         <tr>
                             <th><?php echo _('Find') ?></th>
-                            <td><?php echo $this->Number->format($submission->pfind_easy, ['places' => 2, 'precision' => 2]) ?> kIOP/s</td>
+                            <td><?php echo $this->Number->format($submission->find_easy, ['places' => 2, 'precision' => 2]) ?> kIOP/s</td>
                         </tr>
                     </table>
                 </div>


### PR DESCRIPTION
Fix the value reported in the "find" field when viewing submissions.
Otherwise it always prints "FIND: 0.00", even though the list shows
valid "find" results for the submission.