### PR TITLE
Improve details of running and submission

### DIFF
--- a/templates/Pages/about.php
+++ b/templates/Pages/about.php
@@ -88,18 +88,17 @@
 
     <ul>
         <li>
-            <a href="https://www.vi4io.org/_media/io500/about/io500-establishing.pdf">White paper: Establishing the IO-500 Benchmark</a>
+            <a class="link" href="https://www.vi4io.org/_media/io500/about/io500-establishing.pdf">White paper: Establishing the IO-500 Benchmark</a>
         </li>
         <li>
-            <a href="https://hps.vi4io.org/_media/research/publications/2018/dltvifiatikl18-the_virtual_institute_for_i_o_and_the_io_500.pdf">Poster: The Virtual Institute for I/O and the IO-500</a>
+            <a class="link" href="https://hps.vi4io.org/_media/research/publications/2018/dltvifiatikl18-the_virtual_institute_for_i_o_and_the_io_500.pdf">Poster: The Virtual Institute for I/O and the IO-500</a>
         </li>
         <li>
             See also various presentations on our
-            <?php echo $this->Html->link(__('news page'), [
-                    'controller' => 'pages',
-                    'action' => 'display',
-                    'news'
-                ]);
+            <?php echo $this->Html->link(__('news page'),
+	        [ 'controller' => 'pages', 'action' => 'display',
+                  'news'
+                ], [ 'class' => 'link' ]);
              ?>.
         </li>
     </ul>

--- a/templates/Pages/additional-roles.php
+++ b/templates/Pages/additional-roles.php
@@ -46,7 +46,7 @@ Salary
 </ol>
 
     <p>
-        The committee can be reached at <a href="mailto:committee@io500.org"><span class="code">committee@io500.org</span></a>.
+        The committee can be reached at <a class="link" href="mailto:committee@io500.org"><span class="code">committee@io500.org</span></a>.
     </p>
 
     <div id="disqus_thread"></div>

--- a/templates/Pages/bof_isc19.php
+++ b/templates/Pages/bof_isc19.php
@@ -94,7 +94,9 @@
         </li>
         <li>
             <strong>Community lightning talks</strong> (5 minutes each)<br/>
-            We invite everyone who has something interesting or critcal to submit a short abstract until June 11th to the <a href="mailto:io-500-board@vi4io.org">steering board</a>.
+            We invite everyone who has something interesting or critcal to
+            submit a short abstract until June 11th to the
+            <a class="link" href="mailto:io-500-board@vi4io.org">steering board</a>.
             <ul>
                 <li>
                     <strong>Rationalizing Public Clouds HPC Performance</strong> – <em>Vinay Gaonkar</em>

--- a/templates/Pages/bof_sc16.php
+++ b/templates/Pages/bof_sc16.php
@@ -76,7 +76,7 @@
     <h3>Agenda</h3>
 
     <p>
-        <a href="https://www.vi4io.org/_media/io500/bofs/sc16/sc16-bof-vi4io.pdf">Our BoF summary:</a>
+        <a class="link" href="https://www.vi4io.org/_media/io500/bofs/sc16/sc16-bof-vi4io.pdf">Our BoF summary:</a>
     </p>
 
     <ul>

--- a/templates/Pages/cfs.php
+++ b/templates/Pages/cfs.php
@@ -34,11 +34,10 @@
             first set of tools to ease capturing of this information for
             inclusion with the submission.
             Further details will be released on the
-            <?php echo $this->Html->link(__('submission page'), [
-                    'controller' => 'pages',
-                    'action' => 'display',
-                    'submission'
-                ]);
+            <?php echo $this->Html->link(__('submission page'),
+	        [ 'controller' => 'pages', 'action' => 'display',
+                  'submission'
+                ], [ 'class' => 'link' ]);
              ?>.
         </li>
     </ol>
@@ -94,11 +93,10 @@
     <h3>Birds-of-a-Feather</h3>
     <p>
         Once again, we encourage you to
-        <?php echo $this->Html->link(__('submit'), [
-            'controller' => 'pages',
-            'action' => 'display',
-            'submission'
-          ]);
+        <?php echo $this->Html->link(__('submit'),
+            [ 'controller' => 'pages', 'action' => 'display',
+              'submission'
+            ], [ 'class' => 'link' ]);
          ?>
         to join our community, and to attend our virtual BoF “The IO500 and
         the Virtual Institute of I/O” at ISC 2021, (time to be announced),

--- a/templates/Pages/cfs.php
+++ b/templates/Pages/cfs.php
@@ -24,10 +24,9 @@
             First, there will be a two-week stabilization period during which
             we encourage the community to verify that the benchmark runs
             properly. During this period the benchmark will be updated based
-            upon feedback from the community. The final benchmark will then be
-            released on Monday, May 1st. We expect that runs compliant with
-            the rules made during the stabilization period are valid as the
-            final submission unless a significant defect is found.
+            upon feedback from the community.  We expect that runs compliant
+            with the rules made during the stabilization period will be valid
+            as a final submission unless a significant defect is found.
         </li>
         <li>
             We are now creating a more detailed schema to describe the

--- a/templates/Pages/foundation-new-roles.php
+++ b/templates/Pages/foundation-new-roles.php
@@ -29,7 +29,9 @@ As with all roles with IO500 Foundation, this is an unpaid position.
 
 
     <p>
-        The committee can be reached at <a href="mailto:committee@io500.org"><span class="code">committee@io500.org</span></a>.
+        The committee can be reached at
+        <a class="link" href="mailto:committee@io500.org">
+        <span class="code">committee@io500.org</span></a>.
     </p>
 
     <div id="disqus_thread"></div>

--- a/templates/Pages/news.php
+++ b/templates/Pages/news.php
@@ -6,23 +6,19 @@
     <ul class="news">
         <li>
             <span class="date">2021-04-16</span> The
-                <?php
-                echo $this->Html->link(__('call for submissions'), [
-                    'controller' => 'pages',
-                    'action' => 'display',
-                    'cfs'
-                ]);
+                <?php echo $this->Html->link(__('call for submissions'),
+                    [ 'controller' => 'pages', 'action' => 'display',
+                      'cfs'
+                    ], [ 'class' => 'link' ]);
                 ?>
             for the eighth IO500 list at ISC 2021 sent out.
         </li>
         <li>
             <span class="date">2021-04-14</span>
-                <?php
-                echo $this->Html->link(__('Press Release for April 14, 2021'), [
-                    'controller' => 'pages',
-                    'action' => 'display',
-                    'news-20210414'
-                ]);
+                <?php echo $this->Html->link(__('Press Release for April 14, 2021'),
+                    [ 'controller' => 'pages', 'action' => 'display',
+                      'news-20210414'
+                    ], [ 'class' => 'link' ]);
                 ?>. 
         </li>
         <li>

--- a/templates/Pages/rules_benchmark.php
+++ b/templates/Pages/rules_benchmark.php
@@ -38,7 +38,8 @@
     </ol>
 
     <p>
-       The committee can be reached at <a href="mailto:committee@io500.org">committee@io500.org</a>. 
+       The committee can be reached at
+       <a class="link" href="mailto:committee@io500.org">committee@io500.org</a>. 
     </p>
 
     <div id="disqus_thread"></div>

--- a/templates/Pages/rules_committee.php
+++ b/templates/Pages/rules_committee.php
@@ -41,7 +41,15 @@
             All requests for media interviews are discussed by the full committee who most unanimously decide how to respond.
         </li>
         <li>
-            There are two official channels of communication for the IO500: the Twitter handle and the email address <a href="mailto:committee@io500.org">committee@io500.org</a>. The only mechanism for communicating official IO500 announcements, policies, statements, or decisions is via the email address (hereafter referred to as The Email Address). All communication from The Email Address must be unanimously pre-approved by the full committee. Official communication will also be echoed to the twitter handle.
+            There are two official channels of communication for the IO500:
+            the Twitter handle and the email address
+            <a class="link" href="mailto:committee@io500.org">
+            committee@io500.org</a>. The only mechanism for communicating
+            official IO500 announcements, policies, statements, or decisions
+            is via the email address (hereafter referred to as The Email
+            Address). All communication from The Email Address must be
+            unanimously pre-approved by the full committee. Official
+            communication will also be echoed to the twitter handle.
         </li>
         <ul>
             <li>
@@ -80,7 +88,9 @@
     </ol>
 
     <p>
-        The committee can be reached at <a href="mailto:committee@io500.org"><span class="code">committee@io500.org</span></a>.
+        The committee can be reached at
+	<a class="link" href="mailto:committee@io500.org">
+	<span class="code">committee@io500.org</span></a>.
     </p>
 
     <div id="disqus_thread"></div>

--- a/templates/Pages/rules_membership.php
+++ b/templates/Pages/rules_membership.php
@@ -16,7 +16,17 @@
     <h3>IO500 Committee Membership and Succession Rules v1.0</h3>
 
     <p>
-        The <?php echo $this->Html->link('IO500 committee', ['controller' => 'pages', 'action' => 'display', 'steering'], ['class' => 'link']); ?> is a standards body operating with consensus on all decisions excepting times noted in the committee rules. As such, the work progresses slowly with much deliberation. At times, the committee makeup may change. The following describes the committee makeup and how that form changes over time.
+        The
+        <?php echo $this->Html->link('IO500 committee',
+            [ 'controller' => 'pages', 'action' => 'display',
+              'steering'
+            ], ['class' => 'link']);
+         ?>
+        is a standards body operating with consensus on all decisions
+        excepting times noted in the committee rules. As such, the work
+        progresses slowly with much deliberation. At times, the committee
+        makeup may change. The following describes the committee makeup
+        and how that form changes over time.
     </p>
 
     <ol>
@@ -72,7 +82,9 @@
 
     <ul>
         <li>
-            Submissions are to be sent to the <a href="mailto:committee@io500.org"><span class="code">committee@io500.org</span></a> email address.
+            Submissions are to be sent to the
+            <a class="link" href="mailto:committee@io500.org">
+            <span class="code">committee@io500.org</span></a> email address.
         </li>
         <li>
             Anyone can either self-nominate or be nominated by others.

--- a/templates/Pages/rules_scc_submission.php
+++ b/templates/Pages/rules_scc_submission.php
@@ -17,14 +17,12 @@
 
     <p>
         Please refer to the 
-    <?php
-                echo $this->Html->link(__('IO500 Submission Rules'), [
-                    'controller' => 'pages',
-                    'action' => 'display',
-                    'rules-submission'
-                ]);
-   ?>
-all rules are in effect with three exceptions.
+        <?php echo $this->Html->link(__('IO500 Submission Rules'),
+            [ 'controller' => 'pages', 'action' => 'display',
+              'rules-submission'
+            ], [ 'class' => 'link' ]);
+        ?>
+        all rules are in effect with three exceptions:
     </p>
 
     <ol>

--- a/templates/Pages/rules_submission.php
+++ b/templates/Pages/rules_submission.php
@@ -21,13 +21,14 @@
 
     <ol>
         <li>
-            Submissions are made using the latest version of the IO500 application in GitHub and all binaries should be built according to the instructions in                 <?php
-                echo $this->Html->link(__('Running'), [
-                    'controller' => 'pages',
-                    'action' => 'display',
-                    'running'
-                ]);
-                ?>.
+            Submissions are made using the latest version of the IO500
+            application in GitHub and all binaries should be built according
+            to the instructions in
+            <?php echo $this->Html->link(__('Running'),
+                [ 'controller' => 'pages', 'action' => 'display',
+                  'running'
+                ], [ 'class' => 'link' ]);
+             ?>.
         </li>
         <li>
             Read-after-write semantics: The system must be able to correctly

--- a/templates/Pages/running.php
+++ b/templates/Pages/running.php
@@ -27,7 +27,7 @@
 <div class="content">
     <h3>Preparation</h3>
 
-    <p>The IO500 source code is available at Github:</p>
+    <p>The latest IO500 source code is available from Github:</p>
 
     <p class="code-block">
         $ git clone https://github.com/IO500/io500.git -b io500-isc21<br/>
@@ -38,39 +38,129 @@
     <h3>Installation</h3>
 
     <p>
-        We know that the library libcircle which is required for the pfind test is not easy to get compiled on Cray systems.It is required to modify the configure file to avoid verifying the MPI version by options such as <span class="code">--showme</span> that do not exist on Cray MPI. Check also https://github.com/hpc/libcircle/issues/27
+        The libcircle library, which is required to build the optional pfind
+        command, previously had difficulty compiling on Cray systems. It may
+        be required to modify the configure file to avoid verifying the MPI
+        version by options such as <span class="code">--showme</span> that do
+        not exist on Cray MPI. See
+        <a class="link" href="https://github.com/hpc/libcircle/issues/27">
+        https://github.com/hpc/libcircle/issues/27</a> for more details.
     </p>
 
     <p>
-        A video with the installation procedure is here.
+        A video with the installation procedure is
+        <a class="link" href="https://www.youtube.com/watch?v=RFkuapQ_gkc">
+        here</a>.
     </p>
 
     <h3>Steps</h3>
 
     <ol>
         <li>
-            Create a job submission script (if applicable) to execute the <span class="code">io500.sh</span> script which is located in the <span class="code">io500</span> folder. Provide enough execution time (typically 2h would be enough for the full run) and adjust the reserved resources.
-        </li>
-        <li>
-            Edit the <span class="code">io500.sh</span> file to set allowed parameters, and create a .ini file using "<span class="code">./io500 --list &gt; myconfig.ini</span>" and edit available parameters. Remember that you need to execute all the mandatory tests for a valid submission.
+            Modify the existing <span class="code">io500.sh</span> script to
+            include the information necessary for your scheduler. Provide
+            enough execution time (typically 2h is enough for a full run) and
+            adjust the reserved resources if needed:
             <ul>
                 <li>
-                    Adjust the variables io500_mpirun and to <span class="code">io500_mpiargs</span> according to your system and test case.
+                    The variables <span class="code">io500_mpirun</span>
+                    and <span class="code">io500_mpiargs</span> should be
+                    set according to your system and test case.
                 </li>
                 <li>
-                    Then the following variables could be adjust <span class="code">io500_ior_easy_size</span>, <span class="code">io500_ior_easy_params</span>, <span class="code">io500_mdtest_easy_files_per_proc</span>, <span class="code">io500_ior_hard_writes_per_pro</span>, <span class="code">io500_mdtest_hard_files_per_proc</span> in order to achieve the minimum of 5 minutes executing for IOR easy/hard write, and mdtest easy/hard/write.
+                    The <span class="code">setup()</span> section may optionally
+                    contain commands to create <em>only the top-level</em> test
+                    directories under <span class="code">$workdir</span> for
+                    the <span class="code">ior-hard/easy</span> and
+                    <span class="code">mdtest-hard/easy</span> test phases.
                 </li>
                 <li>
-                    You can add system-specific information to the script, otherwise you can provide it during upload. The info creator helps to create the required output.
+                    You can add system-specific information to the script,
+                    otherwise you can provide this when uploading the results.
+                    The <a href="https://www.vi4io.org/io500-info-creator/">
+                    info-creator</a> helps to create the required output.
                 </li>
             </ul>
         </li>
         <li>
-            Execute your submission job script that runs the
-	    "<span class="code"> io500.sh myconfig.ini</span>" script.
+            Create a new <span class="code">.ini</span> file using e.g.
+            "<span class="code">./io500 --list &gt; myconfig.ini</span>" and
+            edit available parameters appropriately for your environment. In
+            particular, the following parameters are critical to set correctly:
+            <ul>
+                <li>
+                    <span class="code">[global] datadir</span>
+                    (directory where test files will be created)
+                </li>
+                <li>
+                    <span class="code">[global] resultdir</span>
+                    (directory where result files will be written)
+                </li>
+                <li>
+                    <span class="code">[global] api</span>
+                    (storage interface to use, if not POSIX)
+                </li>
+            </ul>
+            Remember that you need to execute all the mandatory phases
+            (ior-easy, ior-hard, mdtest-easy, mdtest-hard, find) for a
+            valid submission.  The following variables could be adjusted
+            in order to achieve the minimum 300 seconds execution time,
+            if the current values are too small for the stonewall timer:
+            <ul>
+                <li>
+                    <span class="code">[ior-easy] blocksize</span>
+                    (maximum data written per rank to a separate file)
+                </li>
+                <li>
+                    <span class="code">[ior-hard] segmentCount</span>
+                    (maximum segments written per rank)
+                </li>
+                <li>
+                    <span class="code">[mdtest-easy] n</span>
+                    (maximum number of files created per rank)
+                </li>
+                <li>
+                    <span class="code">[mdtest-hard] n</span>
+                    (maximum number of files created per rank)
+                </li>
+            </ul>
+            Note the generated .ini file may contain sections for "extended"
+            test phases (<span class="code">ior-rnd</span>,
+             <span class="code">mdworkbench</span>,
+             <span class="code">find-easy</span>, and
+             <span class="code">find-hard</span>) that are not executed as
+            part of the current benchmark and can be ignored.
         </li>
         <li>
-            Verify that all the results are valid.
+            Any modifications to runtime tunables may only be made according
+            to the
+            <?php
+             echo $this->Html->link(__('IO500 Submission Rules'), [
+                 'controller' => 'pages',
+                 'action' => 'display',
+                 'rules-submission'
+             ]);
+             ?>.
+        </li>
+        <li>
+            Execute "<span class="code">io500.sh myconfig.ini</span>" directly
+            or via a batch job submission.
+        </li>
+        <li>
+            Check the resulting output, and verify that none of the results
+            in <span class="code">$resultdir/result_summary.txt</span>
+            are marked <span class="code">[INVALID]</span> (e.g. because of a
+            runtime below 300s, or other error).  There must also be a
+            <span class="code">SCORE</span> line at the end, and it cannot be
+            marked <span class="code">[INVALID]</span> (e.g. due to to a
+            failed or missing required test phase).
+        </li>
+        <li>
+            At any time, you many create a description for your hardware and
+            software environment and save it using the
+            <a class="link" href="https://www.vi4io.org/io500-info-creator/">
+            info-creator tool</a>. You will be asked at submission time to
+            provide the information and can make any final changes.
         </li>
         <li>
             Submit your results, see <a href="https://www.vi4io.org/io500/submission/start">https://www.vi4io.org/io500/submission/start</a>.
@@ -79,17 +169,7 @@
 
     <p>
         A video with the execution and tuning procedure is
-	<a href="https://www.youtube.com/watch?v=FRTK9KwPCmg" class="link">here</a>.
-    </p>
-    <p>
-        When you modify tunables check that the changes are allowed according to the
-                <?php
-                echo $this->Html->link(__('IO500 Submission Rules'), [
-                    'controller' => 'pages',
-                    'action' => 'display',
-                    'rules-submission'
-                ]);
-                ?>.
+        <a href="https://www.youtube.com/watch?v=FRTK9KwPCmg" class="link">here</a>.
     </p>
 
     <div id="disqus_thread"></div>

--- a/templates/Pages/running.php
+++ b/templates/Pages/running.php
@@ -77,7 +77,7 @@
                 <li>
                     You can add system-specific information to the script,
                     otherwise you can provide this when uploading the results.
-                    The <a href="https://www.vi4io.org/io500-info-creator/">
+                    The <a class="link" href="https://www.vi4io.org/io500-info-creator/">
                     info-creator</a> helps to create the required output.
                 </li>
             </ul>
@@ -134,12 +134,10 @@
         <li>
             Any modifications to runtime tunables may only be made according
             to the
-            <?php
-             echo $this->Html->link(__('IO500 Submission Rules'), [
-                 'controller' => 'pages',
-                 'action' => 'display',
-                 'rules-submission'
-             ]);
+            <?php echo $this->Html->link(__('IO500 Submission Rules'),
+                [ 'controller' => 'pages', 'action' => 'display',
+                   'rules-submission'
+                ], [ 'class' => 'link' ]);
              ?>.
         </li>
         <li>
@@ -163,7 +161,7 @@
             provide the information and can make any final changes.
         </li>
         <li>
-            Submit your results, see <a href="https://www.vi4io.org/io500/submission/start">https://www.vi4io.org/io500/submission/start</a>.
+            Submit your results, see <a class="link" href="https://www.vi4io.org/io500/submission/start">https://www.vi4io.org/io500/submission/start</a>.
         </li>
     </ol>
 

--- a/templates/Pages/steering.php
+++ b/templates/Pages/steering.php
@@ -19,7 +19,7 @@
         The community provides suggestions and is asked to provide feedback on relevant questions before decisions are made.
         It is organized officially via Birds-of-a-feather sessions during the ISC-HPC and Supercomputing conference series.
         Everyone is welcome to join the <a href="http://lists.io500.org/listinfo.cgi/io500-io500.org" class="link">mailing list</a> and
-        our <a href="https://join.slack.com/t/io500workspace/shared_invite/zt-hv1i5svr-Yj8HR_wRzEy1bK2s2JX20w" class="link">Slack channel</a> to discuss issues and participate.
+        our <a href="https://join.slack.com/t/io500workspace/shared_invite/zt-j3i9c00k-niCcUHisgLT2JluYhcxlQQ" class="link">Slack channel</a> to discuss issues and participate.
     </p>
 
     <h3>Advisory committee</h3>
@@ -44,10 +44,10 @@
       <li>George Markomanolis</li>
     </ul>
 
-        <h3>Web Designer</h3>
-        <ul>
-            <li>Jean Luca Bez</li>
-        </ul>
+  <h3>Web Designer</h3>
+    <ul>
+      <li>Jean Luca Bez</li>
+    </ul>
 
     <div id="disqus_thread"></div>
 </div>

--- a/templates/Pages/submission.php
+++ b/templates/Pages/submission.php
@@ -20,25 +20,21 @@
     <p>
         This page contains the information about the submission procedure.
         First, you need to
-        <?php
-        echo $this->Html->link(_('run the benchmark'), [
-            'controller' => 'Pages',
-            'action' => 'display',
-            'running'
-        ]);
-        ?>
+        <?php echo $this->Html->link(_('run the benchmark'),
+            [ 'controller' => 'Pages', 'action' => 'display',
+              'running'
+            ], [ 'class' => 'link' ]);
+         ?>
         .
     </p>
 
     <p>
         The IO500 list is released during ISC and SC. See our
-        <?php
-        echo $this->Html->link(_('call for submissions'), [
-            'controller' => 'Pages',
-            'action' => 'display',
-            'cfs'
-        ]);
-        ?>
+        <?php echo $this->Html->link(_('call for submissions'),
+            [ 'controller' => 'Pages', 'action' => 'display',
+              'cfs'
+            ], [ 'class' => 'link' ]);
+         ?>
         page for details.
         Submissions to the upcoming list can be made all year. However,
         <strong>to be included in the next submission</strong>, we must receive
@@ -88,13 +84,11 @@
 
     <p>
         Submissions will be visible immediately to the members of the
-        <?php
-        echo $this->Html->link(_('IO500 Steering Committee'), [
-            'controller' => 'Pages',
-            'action' => 'display',
-            'cfs'
-        ]);
-        ?>.
+        <?php echo $this->Html->link(_('IO500 Steering Committee'),
+            [ 'controller' => 'Pages', 'action' => 'display',
+              'cfs'
+            ], [ 'class' => 'link' ]);
+         ?>.
         If there is sensitivity about early visibility to your results
         being seen by any of the committee, please feel free to email
         results privately to a subset of the committee (i.e. do not use

--- a/templates/Pages/submission.php
+++ b/templates/Pages/submission.php
@@ -19,19 +19,30 @@
 
     <p>
         This page contains the information about the submission procedure.
-        First, you need to     <div class="submissions-action">
+        First, you need to
         <?php
-        echo $this->Html->link(_(' run the benchmark'), [
+        echo $this->Html->link(_('run the benchmark'), [
             'controller' => 'Pages',
             'action' => 'display',
             'running'
         ]);
         ?>
-    </div>.
+        .
     </p>
 
     <p>
-        The IO500 list is released during ISC and SC. See our call for submissions. Submissions to the upcoming list can be made all year. However, <strong>to be included in the next submission</strong>, we must receive the submission until the deadline listed in our call for submissions.
+        The IO500 list is released during ISC and SC. See our
+        <?php
+        echo $this->Html->link(_('call for submissions'), [
+            'controller' => 'Pages',
+            'action' => 'display',
+            'cfs'
+        ]);
+        ?>
+        page for details.
+        Submissions to the upcoming list can be made all year. However,
+        <strong>to be included in the next submission</strong>, we must receive
+        the submission before the deadline listed in our call for submissions.
     </p>
 
     <h3>Submission Instructions</h3>
@@ -62,7 +73,9 @@
     <h3>Handling of the Submitted Data</h3>
 
     <p>
-        Until the submission of the list, the submission committee will handle all submitted data confidentially. That means that we will not disclose any submitted data to individuals/companies, or institutions.
+        Until the next release of the list, the submission committee will
+        handle all submitted data confidentially. That means that we will not
+        disclose any submitted data to individuals/companies, or institutions.
     </p>
 
     <h4>Privacy</h4>
@@ -74,7 +87,18 @@
     <h5>Submitter Name</h5>
 
     <p>
-        Submissions will be visible immediately to the IO500 Committee which currently is comprised of John Bent, Andreas Dilger, Julian Kunkel, Jay Lofstead, and George Markomanolis. If there is sensitivity about early visibility to your results being seen by any of the committee, please feel free to email results privately to a subset of the committee (i.e. do not use the official submission tools if you have privacy concerns).
+        Submissions will be visible immediately to the members of the
+        <?php
+        echo $this->Html->link(_('IO500 Steering Committee'), [
+            'controller' => 'Pages',
+            'action' => 'display',
+            'cfs'
+        ]);
+        ?>.
+        If there is sensitivity about early visibility to your results
+        being seen by any of the committee, please feel free to email
+        results privately to a subset of the committee (i.e. do not use
+        the official submission tools if you have privacy concerns).
     </p>
 
     <p>

--- a/templates/element/header.php
+++ b/templates/element/header.php
@@ -67,6 +67,15 @@
             </li>
             <li>
                 <?php
+                echo $this->Html->link(__('Running'), [
+                    'controller' => 'pages',
+                    'action' => 'display',
+                    'running'
+                ]);
+                ?>
+            </li>
+            <li>
+                <?php
                 echo $this->Html->link(__('Submission'), [
                     'controller' => 'pages',
                     'action' => 'display',
@@ -88,15 +97,6 @@
                 echo $this->Html->link(__('Graphs'), [
                     'controller' => 'submissions',
                     'action' => 'graphs'
-                ]);
-                ?>
-            </li>
-            <li>
-                <?php
-                echo $this->Html->link(__('Running'), [
-                    'controller' => 'pages',
-                    'action' => 'display',
-                    'running'
                 ]);
                 ?>
             </li>


### PR DESCRIPTION
Move the "Running" item before "Submission" in the page header,
since this is the logical order of progression for new users.

Update the running.php page to better describe the current process,
including specific examples of important parameters to be updated.
Mention that ior-rnd, mdworkbench, find-easy/hard can be ignored.

Remove redundant information on running.php and submission.php
to instead link to information on other available pages so it doesn't
need to be updated mulitple times (e.g. stale list of board members).