### PR TITLE
This closes #121 by fixing the URL paths for the plots

### DIFF
--- a/templates/Submissions/graphs.php
+++ b/templates/Submissions/graphs.php
@@ -72,15 +72,15 @@
     <ul class="plots">
         <li>
             <h3>IO500 Score</h3>
-            <iframe src="../webroot/plots/plotly/io500-score.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-score.html"></iframe>
         </li>
         <li>
             <h3>IO500 Bandwidth</h3>
-            <iframe src="../webroot/plots/plotly/io500-bandwidth.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-bandwidth.html"></iframe>
         </li>
         <li>
             <h3>IO500 Metadata</h3>
-            <iframe src="../webroot/plots/plotly/io500-metadata.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-metadata.html"></iframe>
         </li>
     </ul>
 

--- a/templates/Submissions/ior.php
+++ b/templates/Submissions/ior.php
@@ -2,19 +2,19 @@
     <ul class="plots">
         <li>
             <h3>IOR Easy Write</h3>
-            <iframe src="<?php echo $this->Url->build('/'); ?>/webroot/plots/plotly/io500-ior-easy-write.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-ior-easy-write.html"></iframe>
         </li>
         <li>
             <h3>IOR Easy Read</h3>
-            <iframe src="<?php echo $this->Url->build('/'); ?>/webroot/plots/plotly/io500-ior-easy-read.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-ior-easy-read.html"></iframe>
         </li>
         <li>
             <h3>IOR Hard Write</h3>
-            <iframe src="<?php echo $this->Url->build('/'); ?>/webroot/plots/plotly/io500-ior-hard-write.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-ior-hard-write.html"></iframe>
         </li>
         <li>
             <h3>IOR Hard Read</h3>
-            <iframe src="<?php echo $this->Url->build('/'); ?>/webroot/plots/plotly/io500-ior-hard-read.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-ior-hard-read.html"></iframe>
         </li>
     </ul>
 

--- a/templates/Submissions/mdtest.php
+++ b/templates/Submissions/mdtest.php
@@ -2,31 +2,31 @@
     <ul class="plots">
         <li>
             <h3>MDtest Easy Write</h3>
-            <iframe src="<?php echo $this->Url->build('/'); ?>/webroot/plots/plotly/io500-mdtest-easy-write.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-mdtest-easy-write.html"></iframe>
         </li>
         <li>
             <h3>MDtest Easy Stat</h3>
-            <iframe src="<?php echo $this->Url->build('/'); ?>/webroot/plots/plotly/io500-mdtest-easy-stat.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-mdtest-easy-stat.html"></iframe>
         </li>        
         <li>
             <h3>MDtest Easy Delete</h3>
-            <iframe src="<?php echo $this->Url->build('/'); ?>/webroot/plots/plotly/io500-mdtest-easy-delete.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-mdtest-easy-delete.html"></iframe>
         </li>
         <li>
             <h3>MDtest Hard Write</h3>
-            <iframe src="<?php echo $this->Url->build('/'); ?>/webroot/plots/plotly/io500-mdtest-hard-write.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-mdtest-hard-write.html"></iframe>
         </li>
         <li>
             <h3>MDtest Hard Read</h3>
-            <iframe src="<?php echo $this->Url->build('/'); ?>/webroot/plots/plotly/io500-mdtest-hard-read.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-mdtest-hard-read.html"></iframe>
         </li>
         <li>
             <h3>MDtest Hard Stat</h3>
-            <iframe src="<?php echo $this->Url->build('/'); ?>/webroot/plots/plotly/io500-mdtest-hard-stat.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-mdtest-hard-stat.html"></iframe>
         </li>
         <li>
             <h3>MDtest Hard Delete</h3>
-            <iframe src="<?php echo $this->Url->build('/'); ?>/webroot/plots/plotly/io500-mdtest-hard-delete.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-mdtest-hard-delete.html"></iframe>
         </li>
     </ul>
 

--- a/templates/Submissions/pfind.php
+++ b/templates/Submissions/pfind.php
@@ -2,7 +2,7 @@
     <ul class="plots">
         <li>
             <h3>Find</h3>
-            <iframe src="/plots/plotly/io500-find-easy.html"></iframe>
+            <iframe src="/webroot/plots/plotly/io500-find-easy.html"></iframe>
         </li>
     </ul>
 

--- a/templates/Submissions/pfind.php
+++ b/templates/Submissions/pfind.php
@@ -2,7 +2,7 @@
     <ul class="plots">
         <li>
             <h3>Find</h3>
-            <iframe src="<?php echo $this->Url->build('/'); ?>/plots/plotly/io500-find-easy.html"></iframe>
+            <iframe src="/plots/plotly/io500-find-easy.html"></iframe>
         </li>
     </ul>
 


### PR DESCRIPTION
Fix the paths for the plots after `/site` was removed from URL as reported in #121.