### PR TITLE
Display 'find_mixed' field instead of 'find_easy'

### DIFF
--- a/templates/Submissions/view.php
+++ b/templates/Submissions/view.php
@@ -217,7 +217,7 @@
                         </tr>
                         <tr>
                             <th><?php echo _('Find') ?></th>
-                            <td><?php echo $this->Number->format($submission->find_easy, ['places' => 2, 'precision' => 2]) ?> kIOP/s</td>
+                            <td><?php echo $this->Number->format($submission->find_mixed, ['places' => 2, 'precision' => 2]) ?> kIOP/s</td>
                         </tr>
                     </table>
                 </div>


### PR DESCRIPTION
Once the database has been updated to copy the "find_easy" score
into the "find_mixed" field for older submissions, then display
the "find_mixed" field in the details page for the submission.

Issue: #165