### PR TITLE
Create 2021-07-20-update-venus-2-vendor.sql

### DIFF
--- a/sql/2021-07-20-update-venus-2-vendor.sql
+++ b/sql/2021-07-20-update-venus-2-vendor.sql
@@ -1,0 +1,1 @@
+UPDATE submissions SET information_storage_vendor = 'National Supercomputer Center in GuangZhou' WHERE id = 538


### PR DESCRIPTION
As requested, this PR corrects the submission institution from "National" to "National Supercomputer Center in GuangZhou".