### PR TITLE
sql: fix AI400X2 system names

### DIFF
--- a/sql/2022-11-04-update-AI400X2-name.sql
+++ b/sql/2022-11-04-update-AI400X2-name.sql
@@ -1,0 +1,2 @@
+UPDATE submissions SET information_system = 'AI400X2-I' WHERE information_storage_vendor = 'DDN' AND information_system = 'AI400X2' AND id = 615;
+UPDATE submissions SET information_system = 'AI400X2-II' WHERE information_storage_vendor = 'DDN' AND information_system = 'AI400X2' AND id = 595;


### PR DESCRIPTION
Per Shuichi Ihara, split the two AI400X2 results into systems named AI400X2-I and AI400X2-II since they are different systems.