### PR TITLE
cfs: redirect from cfs to submission

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -133,7 +133,7 @@ $routes->scope('/', function (RouteBuilder $builder) {
         [
             'controller' => 'Pages',
             'action' => 'display',
-            'cfs',
+            'submission',
         ]
     );
     $builder->connect(


### PR DESCRIPTION
Redirect the old /cfs URL to the /submission page, so that old links to /cfs will continue to work.