### PR TITLE
Include missing submission

### DIFF
--- a/sql/2023-08-02-update-isc23-arches.sql
+++ b/sql/2023-08-02-update-isc23-arches.sql
@@ -1,0 +1,1 @@
+INSERT INTO list_isc23_10node (listing_id, submission_id, score) VALUES (75, 597, 110.075);


### PR DESCRIPTION
Include previous ISC22 Arches submission back to ISC23 list as requested by the issue opened in our data repository:

https://github.com/IO500/submission-data/issues/2

Once this has been merge a purge in the server cache is needed for the view to update.