### PR TITLE
view all details of submissions

### DIFF
--- a/templates/Questionnaires/view.php
+++ b/templates/Questionnaires/view.php
@@ -30,7 +30,7 @@
                         $submission->id
                     ],
                     [
-                        'class' => 'button'
+                        'class' => 'button-navigation'
                     ]
                 );
             
@@ -55,7 +55,7 @@
                             $submission->id
                         ],
                         [
-                            'class' => 'button-navigation'
+                            'class' => 'button'
                         ]
                     );
                 }

--- a/templates/Questionnaires/view.php
+++ b/templates/Questionnaires/view.php
@@ -19,6 +19,70 @@
 
                 <?php echo h($submission->information_system) ?>
             </h2>
+
+            <div class="submissions-action">
+                <?php
+                echo $this->Html->link(
+                    _('Summary'),
+                    [
+                        'controller' => 'submissions',
+                        'action' => 'view',
+                        $submission->id
+                    ],
+                    [
+                        'class' => 'button'
+                    ]
+                );
+            
+                echo $this->Html->link(
+                    _('Configuration'),
+                    [
+                        'controller' => 'submissions',
+                        'action' => 'configuration',
+                        $submission->id
+                    ],
+                    [
+                        'class' => 'button-navigation'
+                    ]
+                );
+
+                if ($questionnaire) {
+                    echo $this->Html->link(
+                        _('Reproducibility'),
+                        [
+                            'controller' => 'questionnaires',
+                            'action' => 'view',
+                            $submission->id
+                        ],
+                        [
+                            'class' => 'button-navigation'
+                        ]
+                    );
+                }
+
+                if ($submission->repository_url) {
+                    echo $this->Html->link(
+                        _('Files'),
+                        $submission->repository_url,
+                        [
+                            'target' => '_blank',
+                            'class' => 'button-navigation'
+                        ]
+                    );
+                }
+
+                if ($submission->cdcl_url) {
+                    echo $this->Html->link(
+                        _('Data Center'),
+                        $submission->cdcl_url,
+                        [
+                            'class' => 'button-navigation',
+                            'target' => '_blank'
+                        ]
+                    );
+                }
+                ?>
+            </div>
         </div>
     </div>
 </div>

--- a/templates/Submissions/configuration.php
+++ b/templates/Submissions/configuration.php
@@ -1,0 +1,143 @@
+<nav id="breadcrumb">
+    <p>YOU ARE HERE</p>
+
+    <?php
+    $this->Breadcrumbs->add(_('LISTS'), ['controller' => 'releases', 'action' => 'index']);
+    $this->Breadcrumbs->add(strtoupper($submission->information_list_name), ['controller' => 'listings', 'action' => 'list', strtolower($submission->information_list_name), 'io500']);
+    $this->Breadcrumbs->add(strtoupper($submission->information_system), ['controller' => 'submissions', 'action' => 'view', $submission->id]);
+    $this->Breadcrumbs->add(_('CONFIGURATION'), ['controller' => 'submissions', 'action' => 'configuration', $submission->id]);
+
+    echo $this->Breadcrumbs->render([], ['separator' => ' / ']);
+    ?>
+</nav>
+
+<div class="row">
+    <div class="column-responsive column-80">
+        <div class="submissions view content">
+            <h2 class="submissions-name">
+                <?php if ($questionnaire) { ?>
+                <div class="badge badge-<?php echo $questionnaire->reproducibility_score_id; ?>"></div>
+                <?php } ?>
+
+                <?php echo h($submission->information_system); ?>
+            </h2>
+
+            <div class="submissions-action">
+                <?php
+                echo $this->Html->link(
+                    _('Summary'),
+                    [
+                        'controller' => 'submissions',
+                        'action' => 'view',
+                        $submission->id
+                    ],
+                    [
+                        'class' => 'button-navigation'
+                    ]
+                );
+            
+                echo $this->Html->link(
+                    _('Configuration'),
+                    [
+                        'controller' => 'submissions',
+                        'action' => 'configuration',
+                        $submission->id
+                    ],
+                    [
+                        'class' => 'button'
+                    ]
+                );
+
+                if ($questionnaire) {
+                    echo $this->Html->link(
+                        _('Reproducibility'),
+                        [
+                            'controller' => 'questionnaires',
+                            'action' => 'view',
+                            $submission->id
+                        ],
+                        [
+                            'class' => 'button-navigation'
+                        ]
+                    );
+                }
+
+                if ($submission->repository_url) {
+                    echo $this->Html->link(
+                        _('Files'),
+                        $submission->repository_url,
+                        [
+                            'target' => '_blank',
+                            'class' => 'button-navigation'
+                        ]
+                    );
+                }
+
+                if ($submission->cdcl_url) {
+                    echo $this->Html->link(
+                        _('Data Center'),
+                        $submission->cdcl_url,
+                        [
+                            'class' => 'button-navigation',
+                            'target' => '_blank'
+                        ]
+                    );
+                }
+                ?>
+            </div>
+
+            <div class="information">
+                <div id="dcl_wrap"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<?php
+echo $this->Html->css([
+    'https://submission.io500.org/css/dcl.min.css'
+]);
+
+echo $this->Html->script(
+    [
+        'https://submission.io500.org/js/js-yaml.min.js',
+        'https://submission.io500.org/js/c3.min.js',
+        'https://submission.io500.org/js/d3.min.js',
+        'https://submission.io500.org/js/jquery.min.js',
+        'https://submission.io500.org/js/math.min.js',
+        'https://unpkg.com/@popperjs/core@2',
+        'https://unpkg.com/tippy.js@6',
+        'https://submission.io500.org/js/dcl.js',
+        'https://submission.io500.org/js/dcl-load.js',
+        'https://submission.io500.org/js/dcl-move.js',
+        'https://submission.io500.org/js/dcl-vis.js'
+    ],
+    [
+        'block' => 'script'
+    ]
+);
+
+$url_site = 'https://submission.io500.org/files/submissions/' . $submission->id . '.json?timestamp=' . time();
+$url_schema = 'https://submission.io500.org/model/schema-io500.json?timestamp=' . time();
+
+$this->Html->scriptBlock(
+    "
+    $(document).ready(function() {
+        dcl_draw_graph = false;
+        dcl_draw_table = false;
+        dcl_draw_toolbar = false;
+        dcl_draw_aggregation = false;
+        dcl_global_readonly = true;
+
+        dcl_schema = '" . $url_schema . "';
+        dcl_site =  '" . $url_site . "';
+
+        dcl_startup();
+    });
+    ",
+    [
+        'block' => 'script'
+    ]
+);
+?>

--- a/templates/Submissions/view.php
+++ b/templates/Submissions/view.php
@@ -13,18 +13,77 @@
 <div class="row">
     <div class="column-responsive column-80">
         <div class="submissions view content">
-            <h2><?php echo h($submission->information_system) ?></h2>
+            <h2 class="submissions-name">
+                <?php if ($questionnaire) { ?>
+                <div class="badge badge-<?php echo $questionnaire->reproducibility_score_id; ?>"></div>
+                <?php } ?>
 
-            <?php if ($submission->cdcl_url) { ?>
+                <?php echo h($submission->information_system); ?>
+            </h2>
+
             <div class="submissions-action">
                 <?php
-                echo $this->Html->link(_('Data Center List'), $submission->cdcl_url, [
-                    'class' => 'button-navigation',
-                    'target' => '_blank'
-                ]);
+                echo $this->Html->link(
+                    _('Summary'),
+                    [
+                        'controller' => 'submissions',
+                        'action' => 'view',
+                        $submission->id
+                    ],
+                    [
+                        'class' => 'button'
+                    ]
+                );
+            
+                echo $this->Html->link(
+                    _('Configuration'),
+                    [
+                        'controller' => 'submissions',
+                        'action' => 'configuration',
+                        $submission->id
+                    ],
+                    [
+                        'class' => 'button-navigation'
+                    ]
+                );
+
+                if ($questionnaire) {
+                    echo $this->Html->link(
+                        _('Reproducibility'),
+                        [
+                            'controller' => 'questionnaires',
+                            'action' => 'view',
+                            $submission->id
+                        ],
+                        [
+                            'class' => 'button-navigation'
+                        ]
+                    );
+                }
+
+                if ($submission->repository_url) {
+                    echo $this->Html->link(
+                        _('Files'),
+                        $submission->repository_url,
+                        [
+                            'target' => '_blank',
+                            'class' => 'button-navigation'
+                        ]
+                    );
+                }
+
+                if ($submission->cdcl_url) {
+                    echo $this->Html->link(
+                        _('Data Center'),
+                        $submission->cdcl_url,
+                        [
+                            'class' => 'button-navigation',
+                            'target' => '_blank'
+                        ]
+                    );
+                }
                 ?>
             </div>
-            <?php } ?>
 
             <div class="information">
                 <div class="information-metadata">
@@ -75,68 +134,6 @@
                         <tr>
                             <th><?php echo _('Client Kernel Version') ?></th>
                             <td><?php echo h($submission->information_client_kernel_version) ?></td>
-                        </tr>
-                    </table>
-                </div>
-
-                <div class="information-metadata">
-                    <h4>METADATA SERVER</h4>
-
-                    <table class="tb tb-info">
-                        <tr>
-                            <th><?php echo _('Storage Type') ?></th>
-                            <td><?php echo h($submission->information_md_storage_type) ?></td>
-                        </tr>
-                        <tr>
-                            <th><?php echo _('Volatile Memory') ?></th>
-                            <td><?php echo h($submission->information_md_volatile_memory_capacity) ?></td>
-                        </tr>
-                        <tr>
-                            <th><?php echo _('Storage Interface') ?></th>
-                            <td><?php echo h($submission->information_md_storage_interface) ?></td>
-                        </tr>
-                        <tr>
-                            <th><?php echo _('Network') ?></th>
-                            <td><?php echo h($submission->information_md_network) ?></td>
-                        </tr>
-                        <tr>
-                            <th><?php echo _('Software Version') ?></th>
-                            <td><?php echo h($submission->information_md_software_version) ?></td>
-                        </tr>
-                        <tr>
-                            <th><?php echo _('OS Version') ?></th>
-                            <td><?php echo h($submission->information_md_operating_system_version) ?></td>
-                        </tr>
-                    </table>
-                </div>
-
-                <div class="information-data">
-                    <h4>DATA SERVER</h4>
-
-                    <table class="tb tb-info">
-                        <tr>
-                            <th><?php echo _('Storage Type') ?></th>
-                            <td><?php echo h($submission->information_ds_storage_type) ?></td>
-                        </tr>
-                        <tr>
-                            <th><?php echo _('Volatile Memory') ?></th>
-                            <td><?php echo h($submission->information_ds_volatile_memory_capacity) ?></td>
-                        </tr>
-                        <tr>
-                            <th><?php echo _('Storage Interface') ?></th>
-                            <td><?php echo h($submission->information_ds_storage_interface) ?></td>
-                        </tr>
-                        <tr>
-                            <th><?php echo _('Network') ?></th>
-                            <td><?php echo h($submission->information_ds_network) ?></td>
-                        </tr>
-                        <tr>
-                            <th><?php echo _('Software Version') ?></th>
-                            <td><?php echo h($submission->information_ds_software_version) ?></td>
-                        </tr>
-                        <tr>
-                            <th><?php echo _('OS Version') ?></th>
-                            <td><?php echo h($submission->information_ds_operating_system_version) ?></td>
                         </tr>
                     </table>
                 </div>
@@ -261,25 +258,6 @@
                     </table>
                 </div>
             </div>
-
-            <h3>Submitted Files</h3>
-
-            <ul class="file-buttons">
-                <?php if ($submission->repository_url) { ?>
-                <li>
-                    <?php
-                    echo $this->Html->link(
-                        _('Browse in GitHub'),
-                        $submission->repository_url,
-                        [
-                            'target' => '_blank',
-                            'class' => 'button'
-                        ]
-                    );
-                    ?>
-                </li>
-                <?php } ?>
-            </ul>
         </div>
     </div>
 </div>

--- a/webroot/css/default.css
+++ b/webroot/css/default.css
@@ -689,6 +689,10 @@ dd {
     border-radius: 3px;
 }
 
+.submissions-name {
+    width: 100%;
+}
+
 .submissions-action {
     float: right;
     margin: 15px 0;
@@ -943,6 +947,7 @@ footer > .container{
     background-size: 20px;
     background-repeat: no-repeat;
     background-position: center;
+    margin-bottom: -2px;
     width: 20px;
     height: 20px;
 }


### PR DESCRIPTION
Include buttons to view submission details (JSON), files, and the reproducibility questionnaire:

![image](https://github.com/IO500/webpage/assets/5297080/46252d77-ee8a-43a0-9fc6-d89b45bea17a)

If one or more of those are not available, the respective button will not be displayed. For old submissions where we do not have the JSON in the server, a message will be displayed instead of the following page, which shows the submission details in read-only mode:

![image](https://github.com/IO500/webpage/assets/5297080/00cdf910-d584-4b66-8344-315fc4a6b365)


