### PR TITLE
running: remove version tag from checkout

### DIFF
--- a/templates/Pages/running.php
+++ b/templates/Pages/running.php
@@ -36,7 +36,7 @@
     </p>
 
     <p class="code-block">
-        $ git clone https://github.com/IO500/io500.git -b io500-isc24<br/>
+        $ git clone https://github.com/IO500/io500.git<br/>
         $ cd io500<br/>
         $ ./prepare.sh<br/>
     </p>


### PR DESCRIPTION
The instructions for building and running  the benchmark showed a specific tag during checkout, which became stale.

Instead, just check out the latest version, which will have the latest tag.